### PR TITLE
Add a new Route for viewing Post Details

### DIFF
--- a/src/api/services/post/model.js
+++ b/src/api/services/post/model.js
@@ -1,12 +1,13 @@
-import mongoose from 'mongoose';
+import mongoose, { Schema } from 'mongoose';
 
-const Schema = mongoose.Schema;
-
-export default mongoose.model('post',
-  new Schema({
+const PostSchema = new Schema(
+  {
     uuid: { type: String, required: true, unique: true },
     title: { type: String, required: true },
     completed: { type: Boolean, default: false },
-    createdAt: { type: Date, default: Date.now },
-    updatedAt: { type: Date, default: Date.now },
-  }));
+  },
+  {
+    timestamps: true, // Will automatically create and update updatedAt and createdAt Fields
+  });
+
+export default mongoose.model('post', PostSchema);

--- a/src/shared/components/PostCreateModal.jsx
+++ b/src/shared/components/PostCreateModal.jsx
@@ -31,42 +31,44 @@ export default observer(({ open, form }) => (
     onRequestClose={handleCloseModal}
     style={styles}
   >
-    <div className="m3">
-      <h3>Create Post</h3>
-      <form>
-        <div className="pb3">
-          <TextField
-            hintText="Title"
-            floatingLabelText={form.$('title').label}
-            name={form.$('title').name}
-            value={form.$('title').value}
-            errorText={form.$('title').error}
-            onChange={form.$('title').sync}
-          />
-          <Toggle
-            className="pt3"
-            labelPosition="right"
-            label={form.$('completed').label}
-            name={form.$('completed').name}
-            defaultToggled={form.$('completed').value}
-            onToggle={form.$('completed').sync}
-          />
-        </div>
-        <div className="tc">
-          <button
-            type="submit"
-            className={button}
-            onClick={form.onSubmit}
-          >Save</button>
-        </div>
-        <div
-          className={cx(errorMessage, {
-            hide: !form.isValid && form.genericErrorMessage,
-          })}
-        >
-          {form.genericErrorMessage}
-        </div>
-      </form>
-    </div>
+    {!(form && form.$) ? null : (
+      <div className="ma3">
+        <h3>{form.$('uuid').value ? 'Edit' : 'Create'} Post</h3>
+        <form>
+          <div className="pb3">
+            <TextField
+              hintText="Title"
+              floatingLabelText={form.$('title').label}
+              name={form.$('title').name}
+              value={form.$('title').value}
+              errorText={form.$('title').error}
+              onChange={form.$('title').sync}
+            />
+            <Toggle
+              className="pt3"
+              labelPosition="right"
+              label={form.$('completed').label}
+              name={form.$('completed').name}
+              defaultToggled={form.$('completed').value}
+              onToggle={form.$('completed').onChange}
+            />
+          </div>
+          <div className="tc">
+            <button
+              type="submit"
+              className={button}
+              onClick={form.onSubmit}
+            >Save</button>
+          </div>
+          <div
+            className={cx(errorMessage, {
+              hide: !form.isValid && form.genericErrorMessage,
+            })}
+          >
+            {form.genericErrorMessage}
+          </div>
+        </form>
+      </div>
+    )}
   </Modal>
 ));

--- a/src/shared/components/PostDetails.jsx
+++ b/src/shared/components/PostDetails.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { toJS } from 'mobx';
+import { observer } from 'mobx-react';
+import _ from 'lodash';
+
+// components
+import TimeAgo from 'react-timeago';
+
+// styles
+import styles from '@/shared/styles/PostList.css';
+
+const NotLoaded = observer(({ item }) => (
+  <div>
+    <div className="divider border-top" />
+    <h4 className="pt5">Loading ... {!item}</h4>
+  </div>
+));
+
+const ItemDetail = observer(({ item }) => (
+  <div className="cf bg-white br2 pv3 ph4 mb3">
+    <div className="fl w-100 w-60-ns tc tl-ns">
+      <div className="f4 pt3">
+        { item.completed
+          ? <i className="fa fa-check-circle green" />
+          : <i className="fa fa-times-circle red" />}
+        {' '}
+        { item.title }
+      </div>
+      <div className="f5 pt3 gray">ID: { item.uuid }</div>
+    </div>
+    <div className="fl w-100 w-40-ns tc tl-ns">
+      <p><b>Created at</b>: <TimeAgo date={item.createdAt} /></p>
+      <p><b>Updated at:</b> <TimeAgo date={item.updatedAt} /></p>
+    </div>
+  </div>
+));
+
+export default observer(({ item }) => {
+  console.log('Rendering Post Details for item: %o', toJS(item)); // eslint-disable-line
+
+  return (
+    <div className={styles.postList}>
+      {_.isEmpty(item)
+        ? <NotLoaded />
+        : <ItemDetail item={item} />}
+    </div>
+  );
+});

--- a/src/shared/components/PostDetailsHeader.jsx
+++ b/src/shared/components/PostDetailsHeader.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { browserHistory } from 'react-router';
 import { observer } from 'mobx-react';
-// import { dispatch } from 'rfx-core';
-import cx from 'classnames';
+import { dispatch } from 'rfx-core';
 import $ from '@/shared/styles/_.mixins';
 
-const handleEditPost = post => (e) => {
+const handleEditPost = (e) => {
   e.preventDefault();
-  // dispatch('post.edit', post.uuid);
-  alert(`TODO: Implement Editing of Post\n ${post.uuid}`); // eslint-disable-line
+  dispatch('ui.postCreateModal.open', true);
 };
 
 export default observer(({ post }) => (
@@ -20,7 +18,7 @@ export default observer(({ post }) => (
         type="button"
         value="done"
         onClick={() => browserHistory.push('/messages')}
-        className={cx($.buttonPill, '')}
+        className={$.buttonPill}
       >
         <i className="fa fa-chevron-left" /> Messages
       </button>
@@ -30,8 +28,8 @@ export default observer(({ post }) => (
       <button
         type="button"
         value="done"
-        onClick={handleEditPost(post)}
-        className={cx($.buttonPill, '')}
+        onClick={handleEditPost}
+        className={$.buttonPill}
       >
         <i className="fa fa-edit" /> Edit
       </button>

--- a/src/shared/components/PostDetailsHeader.jsx
+++ b/src/shared/components/PostDetailsHeader.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { browserHistory } from 'react-router';
+import { observer } from 'mobx-react';
+// import { dispatch } from 'rfx-core';
+import cx from 'classnames';
+import $ from '@/shared/styles/_.mixins';
+
+const handleEditPost = post => (e) => {
+  e.preventDefault();
+  // dispatch('post.edit', post.uuid);
+  alert(`TODO: Implement Editing of Post\n ${post.uuid}`); // eslint-disable-line
+};
+
+export default observer(({ post }) => (
+  <div className="tc mb4">
+    <h3 className="text-center">{post.name || 'Post Details'}</h3>
+
+    <div className="fl t4">
+      <button
+        type="button"
+        value="done"
+        onClick={() => browserHistory.push('/messages')}
+        className={cx($.buttonPill, '')}
+      >
+        <i className="fa fa-chevron-left" /> Messages
+      </button>
+    </div>
+
+    <div className="fr t4">
+      <button
+        type="button"
+        value="done"
+        onClick={handleEditPost(post)}
+        className={cx($.buttonPill, '')}
+      >
+        <i className="fa fa-edit" /> Edit
+      </button>
+    </div>
+  </div>
+));

--- a/src/shared/components/PostList.jsx
+++ b/src/shared/components/PostList.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { observer } from 'mobx-react';
 
 // components
+import { Link } from 'react-router';
 import TimeAgo from 'react-timeago';
 
 // styles
@@ -25,7 +26,9 @@ const ItemsList = observer(({ items }) => (
               : <i className="fa fa-times-circle red" />
             } {item.title}
           </div>
-          <div className="f5 pt3 gray">ID: {item.uuid}</div>
+          <div className="f5 pt3 gray">
+            ID: <Link to={`/messages/${item.uuid}`}>{item.uuid}</Link>
+          </div>
         </div>
         <div className="fl w-100 w-40-ns tc tl-ns">
           <p><b>Created at</b>: <TimeAgo date={item.createdAt} /></p>

--- a/src/shared/containers/Message.jsx
+++ b/src/shared/containers/Message.jsx
@@ -5,6 +5,7 @@ import { inject, observer } from 'mobx-react';
 import Helmet from 'react-helmet';
 import PostDetailsHeader from '@/shared/components/PostDetailsHeader';
 import PostDetails from '@/shared/components/PostDetails';
+import PostCreateModal from '@/shared/components/PostCreateModal';
 import { authorize } from '@/utils/authorize.hoc';
 
 @inject('store') @authorize @observer
@@ -25,7 +26,7 @@ export default class Message extends Component {
   }
 
   render() {
-    const { post } = this.props.store;
+    const { ui, post } = this.props.store;
 
     return (
       <div className="pt5 ph4">
@@ -34,6 +35,10 @@ export default class Message extends Component {
         <div className="pv4 _c4">
           <PostDetails item={post.selected} />
         </div>
+        <PostCreateModal
+          open={ui.postCreateModal.isOpen}
+          form={post.editForm}
+        />
       </div>
     );
   }

--- a/src/shared/containers/Message.jsx
+++ b/src/shared/containers/Message.jsx
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import { inject, observer } from 'mobx-react';
+
+// Components
+import Helmet from 'react-helmet';
+import PostDetailsHeader from '@/shared/components/PostDetailsHeader';
+import PostDetails from '@/shared/components/PostDetails';
+import { authorize } from '@/utils/authorize.hoc';
+
+@inject('store') @authorize @observer
+export default class Message extends Component {
+  static postForm;
+
+  static fetchData({ store, params }) {
+    console.log('Fetching message data for', params.messageId); // eslint-disable-line
+    return store.post.get(params.messageId);
+  }
+
+  static propTypes = {
+    store: React.PropTypes.object,
+  };
+
+  componentWillUnmount() {
+    return this.props.store.post.clear();
+  }
+
+  render() {
+    const { post } = this.props.store;
+
+    return (
+      <div className="pt5 ph4">
+        <Helmet title="Message Details" />
+        <PostDetailsHeader post={post.selected} />
+        <div className="pv4 _c4">
+          <PostDetails item={post.selected} />
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/shared/forms/post.js
+++ b/src/shared/forms/post.js
@@ -10,7 +10,6 @@ export class PostForm extends Form {
       .then(() => dispatch('ui.postCreateModal.open', false))
       .then(() => dispatch('ui.snackBar.open', 'Post Saved.'))
       .then(() => form.clear())
-      .then(() => form.clear())
       .catch((err) => {
         form.invalidate(err.message);
         dispatch('ui.snackBar.open', err.message);

--- a/src/shared/forms/post.js
+++ b/src/shared/forms/post.js
@@ -1,12 +1,14 @@
 import { dispatch } from 'rfx-core';
+import { action } from 'mobx';
 import Form from './_.extend';
 
-class PostForm extends Form {
-
+export class PostForm extends Form {
   onSuccess(form) {
-    dispatch('post.create', form.values())
+    const storeAction = form.values().uuid ? 'post.update' : 'post.create';
+
+    dispatch(storeAction, form.values())
       .then(() => dispatch('ui.postCreateModal.open', false))
-      .then(() => dispatch('ui.snackBar.open', 'Post Created.'))
+      .then(() => dispatch('ui.snackBar.open', 'Post Saved.'))
       .then(() => form.clear())
       .then(() => form.clear())
       .catch((err) => {
@@ -17,17 +19,24 @@ class PostForm extends Form {
   }
 }
 
-export default
-  new PostForm({
-    fields: {
-      title: {
-        label: 'Title',
-        rules: 'required|string|between:5,50',
-      },
-      completed: {
-        label: 'Completed',
-        value: true,
-        rules: 'boolean',
-      },
-    },
-  });
+export const fields = {
+  title: {
+    label: 'Title',
+    rules: 'required|string|between:5,50',
+  },
+  completed: {
+    label: 'Completed',
+    value: true,
+    rules: 'boolean',
+  },
+  uuid: {
+    rules: 'string',
+    value: null,
+  },
+};
+
+export function init(values = {}) {
+  return new PostForm({ fields, values });
+}
+
+export default new PostForm({ fields });

--- a/src/shared/routes.jsx
+++ b/src/shared/routes.jsx
@@ -17,7 +17,12 @@ export default (
     <IndexRoute getComponent={(loc, cb) => $import(loc, cb, 'Home')} />
 
     <Route path="auth" getComponent={(loc, cb) => $import(loc, cb, 'Auth')} />
-    <Route path="messages" getComponent={(loc, cb) => $import(loc, cb, 'Messages')} />
+
+    <Route path="messages">
+      <IndexRoute getComponent={(loc, cb) => $import(loc, cb, 'Messages')} />
+      <Route path="(:messageId)" getComponent={(loc, cb) => $import(loc, cb, 'Message')} />
+    </Route>
+
     <Route path="packages" getComponent={(loc, cb) => $import(loc, cb, 'Packages')} />
 
     <Route path="*" component={NotFound} status={404} />

--- a/src/shared/stores/post.js
+++ b/src/shared/stores/post.js
@@ -1,9 +1,17 @@
-import { observable, action, computed } from 'mobx';
+import { extendObservable, observable, action, computed } from 'mobx';
 import { service } from '@/shared/app';
 import { factory } from '@/seeds/factories/post'; // just for test
 import _ from 'lodash';
 
 export default class PostStore {
+
+  static post = {
+    uuid: null,
+    title: null,
+    completed: null,
+    createdAt: null,
+    updatedAt: null,
+  };
 
   query = {};
 
@@ -12,6 +20,8 @@ export default class PostStore {
   @observable filter = 'all';
 
   @observable list = [];
+
+  @observable selected = _.clone(PostStore.post);
 
   /*
     "total": "<total number of records>",
@@ -32,6 +42,27 @@ export default class PostStore {
     // service('post').on('updated', action(this.onUpdated));   // onUpdated = (id, data) => {}
     // service('post').on('patched', action(this.onPatched));   // onPatched = (id, data) => {}
     // service('post').on('removed', action(this.onRemoved));   // onRemoved = (id, params) => {}
+  }
+
+
+  @action
+  setSelected(json = {}) {
+    if (_.isEmpty(json)) {
+      return this.clearSelected();
+    }
+
+    console.log('Setting Selected Company: %o', json); //eslint-disable-line
+    extendObservable(this.selected, json);
+
+    return this.selected;
+  }
+
+  @action
+  clearSelected() {
+    extendObservable(this.selected, PostStore.post);
+    console.assert(!this.selected.uuid, 'Selected Object UUID must be null'); // eslint-disable-line
+
+    return this.selected;
   }
 
   @action
@@ -65,6 +96,21 @@ export default class PostStore {
     return service('post')
       .create(data || factory())
       .catch(err => console.error(err)); // eslint-disable-line no-console
+  }
+
+  get(id) {
+    if (_.isEmpty(id)) {
+      return Promise.reject('Must Specify Message ID');
+    }
+
+    return service('post')
+      .get(id)
+      .then(post => this.setSelected(post))
+      .catch(err => console.error(err)); // eslint-disable-line no-console
+  }
+
+  clear() {
+    return this.clearSelected();
   }
 
   find(query = {}) {

--- a/src/shared/stores/post.js
+++ b/src/shared/stores/post.js
@@ -1,7 +1,10 @@
+import _ from 'lodash';
 import { extendObservable, observable, action, computed } from 'mobx';
+
 import { service } from '@/shared/app';
 import { factory } from '@/seeds/factories/post'; // just for test
-import _ from 'lodash';
+
+import postForm, { init as initPostForm } from '@/shared/forms/post';
 
 export default class PostStore {
 
@@ -23,6 +26,8 @@ export default class PostStore {
 
   @observable selected = _.clone(PostStore.post);
 
+  @observable editForm = postForm;
+
   /*
     "total": "<total number of records>",
     "limit": "<max number of items per page>",
@@ -39,8 +44,8 @@ export default class PostStore {
 
   initEvents() {
     service('post').on('created', action(this.onCreated));  // onCreated = (data, params) => {}
-    // service('post').on('updated', action(this.onUpdated));   // onUpdated = (id, data) => {}
-    // service('post').on('patched', action(this.onPatched));   // onPatched = (id, data) => {}
+    service('post').on('updated', action(this.onUpdated));   // onUpdated = (data) => {}
+    service('post').on('patched', action(this.onPatched));   // onPatched = (data) => {}
     // service('post').on('removed', action(this.onRemoved));   // onRemoved = (id, params) => {}
   }
 
@@ -51,7 +56,9 @@ export default class PostStore {
       return this.clearSelected();
     }
 
-    console.log('Setting Selected Company: %o', json); //eslint-disable-line
+    this.editForm = initPostForm(json);
+
+    console.log('Setting Selected Post: %o', json); //eslint-disable-line
     extendObservable(this.selected, json);
 
     return this.selected;
@@ -61,6 +68,8 @@ export default class PostStore {
   clearSelected() {
     extendObservable(this.selected, PostStore.post);
     console.assert(!this.selected.uuid, 'Selected Object UUID must be null'); // eslint-disable-line
+
+    this.editForm = postForm;
 
     return this.selected;
   }
@@ -98,6 +107,12 @@ export default class PostStore {
       .catch(err => console.error(err)); // eslint-disable-line no-console
   }
 
+  update(data = {}, id = data.uuid) {
+    return service('post')
+      .patch(id, data)
+      .catch(err => console.error(err)); // eslint-disable-line no-console
+  }
+
   get(id) {
     if (_.isEmpty(id)) {
       return Promise.reject('Must Specify Message ID');
@@ -124,9 +139,21 @@ export default class PostStore {
 
   onCreated = item => this.addItem(item);
 
-  // onUpdated = (id, data) => {};
+  @action
+  onUpdated = (data) => {
+    console.log('Received Post Update: %O', data); // eslint-disable-line
 
-  // onPatched = (id, data) => {};
+    const existing = _.find(this.list, { uuid: data.uuid });
+    if (existing) {
+      _.extend(existing, data);
+    }
+
+    if (this.selected.uuid === data.uuid) {
+      _.extend(this.selected, data);
+    }
+  };
+
+  onPatched = this.onUpdated;
 
   // onRemoved = (id, params) => {};
 


### PR DESCRIPTION
This PR adds a new route to display a Post's Details: `/messages/:messageId`. At this point, the post details are displayed identically to the post details in the list view (`PostList.jsx`), but the contents of the details have been split into a standalone component: `PostDetails.jsx`. On the post details page, there is a placeholder to implement edit-functionality, which at this time only brings up an alert.

I'd love to hear your feedback on my approach.