### PR TITLE
Lock in `mobx-react-form@~1.31.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mobx": "^3.0.2",
     "mobx-react": "^4.1.0",
     "mobx-react-devtools": "^4.2.11",
-    "mobx-react-form": "^1.30.0",
+    "mobx-react-form": "~1.31.0",
     "mobx-react-form-devtools": "^1.6.0",
     "mobx-react-matchmedia": "^1.3.1",
     "moment": "2.17.1",


### PR DESCRIPTION
Lock in `mobx-react-form@~1.31.0` until code can be migrated to support the new form initialization format. See https://github.com/foxhound87/mobx-react-form/issues/323 for more